### PR TITLE
Fix: owner, group for the shared src folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,9 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = "zion"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder "src", "/home/trinity/src", create: true
+  config.vm.synced_folder "src", "/home/trinity/src", create: true,
+  owner: "trinity",
+  group: "trinity"
 
   if Vagrant.has_plugin?("vagrant-timezone")
     config.timezone.value = :host


### PR DESCRIPTION
- The owner and group for the src folder was being reset
  as vagrant/vagrant. They did initially appear to be trinity/trinity.
  But after a couple of vagrant reloads the owner and group changed to
  vagrant/vagrant and causing permission issues.
- Added a simple quick fix to the vagrant file to ensure it remains
  trinity forever.
  - By: Kushal Bhandari / kbhandar@buffalo.edu
