### PR TITLE
Remove 'apt-get upgrade' during bootstrap

### DIFF
--- a/.provision/provision.sh
+++ b/.provision/provision.sh
@@ -9,7 +9,6 @@ add-apt-repository ppa:git-core/ppa > /dev/null 2>&1 && true
 
 echo "set grub-pc/install_devices /dev/sda" | debconf-communicate
 apt-get -y update
-apt-get -y upgrade
 
 # 24 Dec 2015 : GWA : Install OS/161 toolchain and Git.
 apt-get install -y os161-toolchain git git-doc


### PR DESCRIPTION
The previous shell script, at time of writing, failed to bootstrap with the
following message:

    Configuration file '/etc/sudoers'
     ==> Modified (by you or by a script) since installation.
     ==> Package distributor has shipped an updated version.
       What would you like to do about it ?  Your options are:
        Y or I  : install the package maintainer's version
        N or O  : keep your currently-installed version
          D     : show the differences between the versions
          Z     : start a shell to examine the situation
     The default action is to keep your current version.
    *** sudoers (Y/I/N/O/D/Z) [default=N] ?

Remove `apt-get upgrade` since it may require user input, which is not
available during bootstrapping.